### PR TITLE
出荷先会社登録ページ

### DIFF
--- a/app/Http/Controllers/ItemsController.php
+++ b/app/Http/Controllers/ItemsController.php
@@ -17,7 +17,7 @@ class ItemsController extends Controller
     {
         $items = DB::table('items')
             ->leftJoin('favorite', 'favorite.product_id', '=', 'items.id')
-            ->select(DB::raw('items.id as id, items.product_name as product_name, items.arrival_source as arrival_source, items.manufacturer as manufacturer, items.created_at as created_at, items.updated_at as updated_at, count(favorite.user_id=?) as is_favorite'))
+            ->select(DB::raw('items.id as id, items.product_name as product_name, items.arrival_source as arrival_source, items.manufacturer as manufacturer,items.price as price, items.created_at as created_at, items.updated_at as updated_at, count(favorite.user_id=?) as is_favorite'))
             ->setBindings([Auth::user()["id"]])
             ->groupBy('items.id')
             ->paginate(5);

--- a/app/Http/Controllers/ShippingsController.php
+++ b/app/Http/Controllers/ShippingsController.php
@@ -77,4 +77,8 @@ class ShippingsController extends Controller
     {
         return view('shipping/edit_complete');
     }
+    public function create()
+    {
+        return view('shippings/create');
+    }
 }

--- a/app/Http/Controllers/ShippingsController.php
+++ b/app/Http/Controllers/ShippingsController.php
@@ -3,6 +3,8 @@
 namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+
 use Illuminate\Support\Facades\DB;
 
 use App\Models\Shipping;
@@ -80,5 +82,32 @@ class ShippingsController extends Controller
     public function create()
     {
         return view('shippings/create');
+    }
+    public function add(Request $request)
+    {
+        $input = $request->only($this->shippingElements);
+        $validator = [
+            "name" => "required|string",
+            "address" => "required|string",
+            "tel" => "required|string",
+        ];
+
+        $request->validate($validator);
+
+        try {
+            //code...
+            DB::table('shippings')->insert(
+                [
+                    'name' => $input["name"],
+                    'address' => $input["address"],
+                    'tel' => $input["tel"],
+                    'created_at' => now(),
+                ]
+            );
+            $resMsg = now() . 'に' . $input['name'] . 'を出荷先に追加しました';
+            return Response($resMsg, Response::HTTP_OK);
+        } catch (\Exception $e) {
+            return Response($e, Response::HTTP_INTERNAL_SERVER_ERROR);
+        }
     }
 }

--- a/resources/views/items/index.blade.php
+++ b/resources/views/items/index.blade.php
@@ -31,7 +31,7 @@
             <td class="product_name">{{$item->product_name}}</td>
             <td class="arrival_source">{{$item->arrival_source}}</td>
             <td class="manufacturer">{{$item->manufacturer}}</td>
-            <td class="manufacturer">{{$item->price}}</td>
+            <td class="price">{{$item->price}}</td>
             {{-- <td class="created_at">{{$item->created_at}}</td> --}}
             {{-- <td class="updated_at">{{$item->updated_at}}</td> --}}
             <td class="is_favorite">{{$item->is_favorite==1 ? '○' : '×'}}</td>

--- a/resources/views/shippings/create.blade.php
+++ b/resources/views/shippings/create.blade.php
@@ -1,0 +1,37 @@
+@extends('layouts.app')
+
+@section('content')
+  <h4>出荷先登録</h4>
+  @if ($errors->any())
+    <div class="alert alert-danger">
+      <ul>
+        @foreach ($errors->all() as $error)
+            <li>{{ $error }}</li>
+        @endforeach
+      </ul>
+    </div>
+    <?php
+      $name = old('name');
+      $address = old('address');
+      $tel = old('tel');
+    ?>  
+  @endif
+  <div class="w-50" id="ajax-contents">
+      <div class="form-group">
+        <label for="product_name">出荷先名(必須)</label>
+        <input id="name" class="form-control" type="text" name="name" value="{{ old('name')}}">
+      </div>
+      <div class="form-group">
+        <label for="address">住所(必須)</label>
+        <input id="address" class="form-control" type="text" name="address" value="{{ old('address')}}">
+      </div>
+      <div class="form-group">
+        <label for="tel">TEL(必須)
+        </label>
+        <input id="tel" class="form-control" type="text" name="manufacturer" value="{{ old('tel')}}">
+      </div>
+      <button type="submit" class="btn btn-primary">登録</button>
+  </div>
+
+
+@endsection

--- a/resources/views/shippings/create.blade.php
+++ b/resources/views/shippings/create.blade.php
@@ -30,8 +30,66 @@
         </label>
         <input id="tel" class="form-control" type="text" name="manufacturer" value="{{ old('tel')}}">
       </div>
-      <button type="submit" class="btn btn-primary">登録</button>
+      <button id="shipping-register" class="btn btn-primary">登録</button>
   </div>
+  <div id="ajax-confirm"></div>
+  <div id="ajax-finished"></div>
+  <script>
+    window.onload = function(){
+      $("#shipping-register").click(function(event){
+        const shipping_name = $("#name").val();
+        const shipping_address = $("#address").val();
+        const shipping_tel = $("#tel").val();
+        console.log(shipping_name);
+        const confirmHTML = `<div class="form-group">
+                              <label>出荷先名</label>
+                              <div>${shipping_name}</div>
+                            </div>      
+                            <div class="form-group">
+                              <label>住所</label>
+                              <div>${shipping_address}</div>
+                            </div>
+                            <div class="form-group">
+                              <label>TEL</label>
+                              <div>${shipping_tel}</div>
+                            </div>
+                            <button id="confirm-back" class="btn btn-secondary">戻る</button>
+                            <button id="confirm-register" class="btn btn-primary">登録</button>
+                          `;
+        $("#ajax-contents").remove();
+        $("#ajax-confirm").append(confirmHTML);
+        document.querySelector('#confirm-register').addEventListener("click", function () {
+          $.ajax({
+            headers: {
+              'X-CSRF-TOKEN': $('meta[name="csrf-token"]').attr('content')
+            },
+            url: "/shipping/add",
+            type: "POST",
+            data: {
+              'name': shipping_name,
+              'address': shipping_address,
+              'tel': shipping_tel,
+            },
+
+          }).done(function(data){
+            const finishedHTML = `<h3>登録完了</h3>
+                                  <p>${data}</p>
+                                  <a href="{{url('/items')}}">戻る</a>`;
+            $("#ajax-confirm").remove();
+            $("#ajax-finished").append(finishedHTML);
+          }).fail(function(err){
+            console.log(err);
+          });
+          ;
+
+        });
+
+      });
+
+
+    };
+    
+  </script>
 
 
 @endsection

--- a/resources/views/shippings/create.blade.php
+++ b/resources/views/shippings/create.blade.php
@@ -2,33 +2,21 @@
 
 @section('content')
   <h4>出荷先登録</h4>
-  @if ($errors->any())
-    <div class="alert alert-danger">
-      <ul>
-        @foreach ($errors->all() as $error)
-            <li>{{ $error }}</li>
-        @endforeach
-      </ul>
+    <div id="shipping-error-info" class="alert alert-danger d-none">
     </div>
-    <?php
-      $name = old('name');
-      $address = old('address');
-      $tel = old('tel');
-    ?>  
-  @endif
   <div class="w-50" id="ajax-contents">
       <div class="form-group">
         <label for="product_name">出荷先名(必須)</label>
-        <input id="name" class="form-control" type="text" name="name" value="{{ old('name')}}">
+        <input id="name" class="form-control" type="text" name="name">
       </div>
       <div class="form-group">
         <label for="address">住所(必須)</label>
-        <input id="address" class="form-control" type="text" name="address" value="{{ old('address')}}">
+        <input id="address" class="form-control" type="text" name="address">
       </div>
       <div class="form-group">
         <label for="tel">TEL(必須)
         </label>
-        <input id="tel" class="form-control" type="text" name="manufacturer" value="{{ old('tel')}}">
+        <input id="tel" class="form-control" type="text" name="manufacturer">
       </div>
       <button id="shipping-register" class="btn btn-primary">登録</button>
   </div>
@@ -36,55 +24,112 @@
   <div id="ajax-finished"></div>
   <script>
     window.onload = function(){
-      $("#shipping-register").click(function(event){
-        const shipping_name = $("#name").val();
-        const shipping_address = $("#address").val();
-        const shipping_tel = $("#tel").val();
-        console.log(shipping_name);
-        const confirmHTML = `<div class="form-group">
-                              <label>出荷先名</label>
-                              <div>${shipping_name}</div>
-                            </div>      
-                            <div class="form-group">
-                              <label>住所</label>
-                              <div>${shipping_address}</div>
+      function registerListen() {
+        document.querySelector('#shipping-register').addEventListener("click", function () {
+          $("#shipping-error-info").addClass('d-none');
+          $("#shipping-error-info").empty();
+          const shipping_name = $("#name").val();
+          const shipping_address = $("#address").val();
+          const shipping_tel = $("#tel").val();
+          const inputHTML = `<div class="form-group">
+                              <label for="product_name">出荷先名(必須)</label>
+                              <input id="name" class="form-control" type="text" name="name" value="${shipping_name}">
                             </div>
                             <div class="form-group">
-                              <label>TEL</label>
-                              <div>${shipping_tel}</div>
+                              <label for="address">住所(必須)</label>
+                              <input id="address" class="form-control" type="text" name="address" value="${shipping_address}">
                             </div>
-                            <button id="confirm-back" class="btn btn-secondary">戻る</button>
-                            <button id="confirm-register" class="btn btn-primary">登録</button>
-                          `;
-        $("#ajax-contents").remove();
-        $("#ajax-confirm").append(confirmHTML);
-        document.querySelector('#confirm-register').addEventListener("click", function () {
-          $.ajax({
-            headers: {
-              'X-CSRF-TOKEN': $('meta[name="csrf-token"]').attr('content')
-            },
-            url: "/shipping/add",
-            type: "POST",
-            data: {
-              'name': shipping_name,
-              'address': shipping_address,
-              'tel': shipping_tel,
-            },
+                            <div class="form-group">
+                              <label for="tel">TEL(必須)</label>
+                              <input id="tel" class="form-control" type="text" name="manufacturer" value="${shipping_tel}">
+                            </div>
+                              <button id="shipping-register" class="btn btn-primary">登録</button>
+                            </div>
+                            `;
 
-          }).done(function(data){
-            const finishedHTML = `<h3>登録完了</h3>
-                                  <p>${data}</p>
-                                  <a href="{{url('/items')}}">戻る</a>`;
-            $("#ajax-confirm").remove();
-            $("#ajax-finished").append(finishedHTML);
-          }).fail(function(err){
-            console.log(err);
+          const confirmHTML = `<div class="form-group">
+                                <label>出荷先名</label>
+                                <div>${shipping_name}</div>
+                              </div>      
+                              <div class="form-group">
+                                <label>住所</label>
+                                <div>${shipping_address}</div>
+                              </div>
+                              <div class="form-group">
+                                <label>TEL</label>
+                                <div>${shipping_tel}</div>
+                              </div>
+                              <button id="confirm-back" class="btn btn-secondary">戻る</button>
+                              <button id="confirm-register" class="btn btn-primary">登録</button>
+                            `;
+          $("#ajax-contents").empty();
+          $("#ajax-confirm").append(confirmHTML);
+          window.history.pushState(null, null, '/shipping/confirm');
+          window.addEventListener('popstate', function(event){
+            // event.preventDefault();
+            $("#ajax-confirm").empty();
+            $("#ajax-contents").empty();
+            $("#ajax-contents").append(inputHTML);
+            window.history.replaceState(null, null,'/shipping/create');
+            registerListen();
           });
-          ;
+          document.querySelector('#confirm-back').addEventListener("click", function () {
+            $("#ajax-confirm").empty();
+            $("#ajax-contents").append(inputHTML);
+            window.history.replaceState(null, null,'/shipping/create');
+            registerListen();
+          });
+          document.querySelector('#confirm-register').addEventListener("click", function () {
+            $.ajax({
+              headers: {
+                'X-CSRF-TOKEN': $('meta[name="csrf-token"]').attr('content')
+              },
+              url: "/shipping/add",
+              type: "POST",
+              data: {
+                'name': shipping_name,
+                'address': shipping_address,
+                'tel': shipping_tel,
+              },
+
+            }).done(function(data){
+              const finishedHTML = `<h3>登録完了</h3>
+                                    <p>${data}</p>
+                                    <a href="{{url('/items')}}">商品一覧に戻る</a>`;
+              $("#ajax-confirm").remove();
+              $("#ajax-finished").append(finishedHTML);
+              window.history.replaceState(null, null,'/shipping/complete');
+              window.addEventListener('popstate', function(event){
+                $("#ajax-finished").empty();
+                $("#ajax-contents").empty();
+                $("#ajax-contents").append(inputHTML);
+                window.history.replaceState(null, null,'/shipping/create');
+                registerListen();
+              });
+
+            }).fail(function(err){
+              const responseError = JSON.parse(err.responseText).errors;
+              let errorList = '';
+              Object.keys(responseError).forEach(key => {
+                errorList = `${errorList} <li>${responseError[key]}</li>`;
+              });
+              const errorHTML = `<ul>${errorList}</ul>`;
+              $("#shipping-error-info").append(errorHTML);
+              $("#shipping-error-info").removeClass('d-none');
+              $("#ajax-confirm").empty();
+              $("#ajax-contents").append(inputHTML);
+              window.history.replaceState(null, null,'/shipping/create');
+              registerListen();
+              
+            });
+
+          });
 
         });
+      }
 
-      });
+      registerListen();
+
 
 
     };

--- a/routes/web.php
+++ b/routes/web.php
@@ -60,6 +60,8 @@ Route::get('/shipping/edit_confirm', [App\Http\Controllers\ShippingsController::
 Route::post('/shipping/update', [App\Http\Controllers\ShippingsController::class, 'update'])->name("shipping.update");
 Route::get('/shipping/edit_complete', [App\Http\Controllers\ShippingsController::class, 'edit_complete'])->name("shipping.edit_complete");
 Route::get('/shipping/create', [App\Http\Controllers\ShippingsController::class, 'create'])->name("shipping.create");
+Route::post('/shipping/add', [App\Http\Controllers\ShippingsController::class, 'add'])->name("shipping.add");
+
 
 
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -59,6 +59,8 @@ Route::post('/shipping/edit_post', [App\Http\Controllers\ShippingsController::cl
 Route::get('/shipping/edit_confirm', [App\Http\Controllers\ShippingsController::class, 'edit_confirm'])->name("shipping.edit_confirm");
 Route::post('/shipping/update', [App\Http\Controllers\ShippingsController::class, 'update'])->name("shipping.update");
 Route::get('/shipping/edit_complete', [App\Http\Controllers\ShippingsController::class, 'edit_complete'])->name("shipping.edit_complete");
+Route::get('/shipping/create', [App\Http\Controllers\ShippingsController::class, 'create'])->name("shipping.create");
+
 
 
 


### PR DESCRIPTION
・入力画面⇨確認画面⇨完了画面の構造で作成しました。
・上記３画面は全て非同期通信で処理するように実装しました（ページ遷移jはしていません）。
・javascriptのhistory機能を使用し、URLを変更させました。
・「Shippingsテーブル」を作成しました。
・確認画面内に「送信」ボタンを設置し、押下することでShippingsテーブルにajaxでレコード追加するように実装しました。
・戻るボタン押下時にURLに対応した画面表示にしました。