### PR TITLE
商品一覧ソート機能

### DIFF
--- a/app/Http/Controllers/ItemsController.php
+++ b/app/Http/Controllers/ItemsController.php
@@ -16,6 +16,7 @@ class ItemsController extends Controller
     public function index()
     {
         $keyword = request('keyword');
+        $sort_key = request('sort') ? explode('-', request('sort')) : ['id', 'asc'];
         $items = DB::table('items')
             ->leftJoin('favorite', 'favorite.product_id', '=', 'items.id')
             ->select(DB::raw('items.id as id, items.product_name as product_name, items.arrival_source as arrival_source, items.manufacturer as manufacturer,items.price as price, items.created_at as created_at, items.updated_at as updated_at, count(favorite.user_id=?) as is_favorite'))
@@ -24,6 +25,7 @@ class ItemsController extends Controller
             ->where('items.product_name', 'like', '%' . $keyword . '%')
             ->orWhere('items.arrival_source', 'like', '%' . $keyword . '%')
             ->orWhere('items.manufacturer', 'like', '%' . $keyword . '%')
+            ->orderBy($sort_key[0], $sort_key[1])
             ->paginate(5);
 
         return view('items/index', ['items' => $items]);

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -30,3 +30,23 @@ Vue.component('example-component', require('./components/ExampleComponent.vue').
 const app = new Vue({
     el: '#app',
 });
+const headerMenu = function() {
+    $(document).on('click',function(event){
+        if ($(event.target).closest('#mypage_inquiry').length) {
+            $("#mypage_inquiry_list").removeClass("d-none");                    
+        } else{
+            $("#mypage_inquiry_list").addClass("d-none");                    
+
+        }
+        if ($(event.target).closest('#products_shippings').length) {
+            $("#products_shippings_list").removeClass("d-none");
+        }else{
+            $("#products_shippings_list").addClass("d-none");                    
+        }
+    });
+    $(".menu__close").click(function (e) { 
+        $(this).parent().addClass('d-none');
+        
+    });
+
+}

--- a/resources/views/items/index.blade.php
+++ b/resources/views/items/index.blade.php
@@ -18,12 +18,48 @@
     <table class="table col">
       <thead>
         <tr>
-          <th scope="col">id</th>
-          <th scope="col">商品名</th>
-          <th scope="col">入荷元</th>
-          <th scope="col">製造元</th>
-          <th scope="col">単価</th>
-          {{-- <th scope="col">作成日</th> --}}
+          <th scope="col">
+            <div class="d-flex">
+              <p>id</p>
+              <button class="sort btn btn-secondary ml-1" id="sort-id-asc">↑</button>
+              <button class="sort btn btn-secondary ml-1" id="sort-id-desc">↓</button>
+            </div>
+          </th>
+          <th scope="col">
+            <div class="d-flex">
+              <p>商品名</p>
+              <button class="sort btn btn-secondary ml-1" id="sort-product_name-asc">↑</button>
+              <button class="sort btn btn-secondary ml-1" id="sort-product_name-desc">↓</button>
+            </div>
+          </th>
+          <th scope="col">
+            <div class="d-flex">
+              <p>入荷元</p>
+              <button class="sort btn btn-secondary ml-1" id="sort-arrival_source-asc">↑</button>
+              <button class="sort btn btn-secondary ml-1" id="sort-arrivel_source-desc">↓</button>
+            </div>
+          </th>
+          <th scope="col">
+            <div class="d-flex">
+              <p>製造元</p>
+              <button class="sort btn btn-secondary ml-1" id="sort-manufacturer-asc">↑</button>
+              <button class="sort btn btn-secondary ml-1" id="sort-manufacturer-desc">↓</button>
+            </div>
+          </th>
+          <th scope="col">
+            <div class="d-flex">
+              <p>単価</p>
+              <button class="sort btn btn-secondary ml-1" id="sort-price-asc">↑</button>
+              <button class="sort btn btn-secondary ml-1" id="sort-price-desc">↓</button>
+            </div>
+          </th>
+          <th scope="col">
+            <div class="d-flex">
+              <p>作成日</p>
+              <button class="sort btn btn-secondary ml-1" id="sort-created_at-asc">↑</button>
+              <button class="sort btn btn-secondary ml-1" id="sort-created_at-desc">↓</button>
+            </div>
+          </th>
           {{-- <th scope="col">更新日</th> --}}
           <th scope="col">お気に入り</th>
           <th scope="col">アクション</th>
@@ -37,7 +73,7 @@
             <td class="arrival_source">{{$item->arrival_source}}</td>
             <td class="manufacturer">{{$item->manufacturer}}</td>
             <td class="price">{{$item->price}}</td>
-            {{-- <td class="created_at">{{$item->created_at}}</td> --}}
+            <td class="created_at">{{$item->created_at}}</td>
             {{-- <td class="updated_at">{{$item->updated_at}}</td> --}}
             <td class="is_favorite">{{$item->is_favorite==1 ? '○' : '×'}}</td>
             <td class="d-flex">
@@ -68,52 +104,68 @@
         </div>
       </div>
     </div>
-    <script>
-      window.onload = function(){
-        $("#item_search_btn").on("click", function () {
-          const search_keyword=$("#item_search_input").val();
-          location.href=`/items?keyword=${search_keyword}`;
-        });
-        $("#modal_delete").on('shown.bs.modal', function(event){
-          const button = $(event.relatedTarget);
-          const product_name = button.data('name');
-          const url = button.data('url');
-          $('#item_delete_candidate_name').text(product_name);
-          $('#item_delete_execute').on('click', function(){
-            location.href = url;
-          });
-        });
-        $(".add_cart").click(function(){
-          const target_num = $(this).parent().children(".item_num");
-          if (!target_num.val()){
-            target_num.val(1);
-          }
-          $.ajax({
-            headers: {
-              'X-CSRF-TOKEN': $('meta[name="csrf-token"]').attr('content')
-            },
-            url: "/cart/add",
-            type: "POST",
-            data:{
-              'user_id': {{Auth::user()["id"]}},
-              'product_id': $(this).data('id'),
-              'item_num': target_num.val()
-            }
-          }).done(function (data) {
-            $("#err_info").text(data);
-            target_num.val("");
-          }).fail(function(data){
-            $("#err_info").text(data);
-          })
-          
-        });
-      }
 
-
-    </script>
     <div>
-      {{ $items->links() }}
+      {{ $items->appends(request()->query())->links() }}
     </div>
   </div>
 
 @endsection
+<script>
+  window.onload = function(){
+    headerMenu();
+    function getParam(name, url) {
+      if (!url) url = window.location.href;
+      name = name.replace(/[\[\]]/g, "\\$&");
+      var regex = new RegExp("[?&]" + name + "(=([^&#]*)|&|#|$)"),
+          results = regex.exec(url);
+      if (!results) return null;
+      if (!results[2]) return '';
+      return decodeURIComponent(results[2].replace(/\+/g, " "));
+    }
+    $("#item_search_btn").on("click", function () {
+      const search_keyword=$("#item_search_input").val();
+      location.href=`/items?keyword=${search_keyword}`;
+    });
+    $(".sort").on("click",function () { 
+      const sort_key = $(this).attr('id').substr(5);
+      const url = getParam('keyword') ? `${location.pathname}?keyword=${getParam('keyword')}&sort=${sort_key}` : `${location.pathname}&sort=${sort_key}`;
+      location.href = url;
+    });
+    $("#modal_delete").on('shown.bs.modal', function(event){
+      const button = $(event.relatedTarget);
+      const product_name = button.data('name');
+      const url = button.data('url');
+      $('#item_delete_candidate_name').text(product_name);
+      $('#item_delete_execute').on('click', function(){
+        location.href = url;
+      });
+    });
+    $(".add_cart").click(function(){
+      const target_num = $(this).parent().children(".item_num");
+      if (!target_num.val()){
+        target_num.val(1);
+      }
+      $.ajax({
+        headers: {
+          'X-CSRF-TOKEN': $('meta[name="csrf-token"]').attr('content')
+        },
+        url: "/cart/add",
+        type: "POST",
+        data:{
+          'user_id': {{Auth::user()["id"]}},
+          'product_id': $(this).data('id'),
+          'item_num': target_num.val()
+        }
+      }).done(function (data) {
+        $("#err_info").text(data);
+        target_num.val("");
+      }).fail(function(data){
+        $("#err_info").text(data);
+      })
+      
+    });
+  }
+
+
+</script>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -98,7 +98,7 @@
         </main>
     </div>
     <script>
-        window.onload = function () {
+        function headerMenu() {
             $(document).on('click',function(event){
                 if ($(event.target).closest('#mypage_inquiry').length) {
                     $("#mypage_inquiry_list").removeClass("d-none");                    


### PR DESCRIPTION
#What
- お気に入りの追加時にカラム数で横に広がるのが気になっていたので作成日のカラムを表示しないようにしていましたが、ソートで閲覧できるようにした方が良いと思い、再び表示するようにしました。
- 検索で入力した文字列及びソートキーのクエリ文字列を保持したままページネーションができるように修正しました。
- 商品一覧の各項目でソートができる様に実装しました。